### PR TITLE
Update listsSegmentsRoot.php (Typo)

### DIFF
--- a/src/lists/segments/listsSegmentsRoot.php
+++ b/src/lists/segments/listsSegmentsRoot.php
@@ -51,6 +51,6 @@ class Lists_Segments extends Lists
             $this->grandchild_resource,
             $class_input
         );
-        return $this->members;
+        return $this->segment_members;
     }
 }


### PR DESCRIPTION
Typo which generates this error when you want to get a list of members from a segment:
Fatal error: Uncaught Error: Call to a member function GET() on null in /path/to/file/... Stack trace: #0 {main} thrown in /path/to/file/...

#### Description of change or the problem you would like to fix
<hr />


#### Description of implementation
<hr />


#### Risks / Mitigations
<hr />
