### PR TITLE
only serialize request payload into JSON if it is an array

### DIFF
--- a/src/Mailchimp.php
+++ b/src/Mailchimp.php
@@ -287,15 +287,15 @@ class Mailchimp
     }
 
     /**
-     * @param $oath_string
+     * @param $oauth_string
      * @return mixed
      * @throws MailchimpException
      */
-    private static function requestAccessToken($oath_string)
+    private static function requestAccessToken($oauth_string)
     {
         $request = self::getStaticRequest();
         $request->setMethod("POST");
-        $request->setPayload($oath_string);
+        $request->setPayload($oauth_string);
         $request->setBaseUrl(MailchimpConnection::TOKEN_REQUEST_URL);
 
         $connection = self::getStaticConnection($request);

--- a/src/Mailchimp.php
+++ b/src/Mailchimp.php
@@ -295,7 +295,7 @@ class Mailchimp
     {
         $request = self::getStaticRequest();
         $request->setMethod("POST");
-        $request->setPayload($oauth_string);
+        $request->setPayload($oauth_string, false);
         $request->setBaseUrl(MailchimpConnection::TOKEN_REQUEST_URL);
 
         $connection = self::getStaticConnection($request);

--- a/src/Requests/MailchimpRequest.php
+++ b/src/Requests/MailchimpRequest.php
@@ -269,8 +269,8 @@ class MailchimpRequest
      */
     public function setPayload($payload)
     {
-		if (is_array($payload))
-			$payload = $this->serializePayload($payload);
+        if (is_array($payload))
+            $payload = $this->serializePayload($payload);
         $this->payload = $payload;
     }
 

--- a/src/Requests/MailchimpRequest.php
+++ b/src/Requests/MailchimpRequest.php
@@ -265,11 +265,12 @@ class MailchimpRequest
     /**
      * Sets the payload for a request
      * @param mixed $payload
+     * @param boolean $shouldSerialize
      * @throws MailchimpException when cant serialize payload
      */
-    public function setPayload($payload)
+    public function setPayload($payload, $shouldSerialize = true))
     {
-        if (is_array($payload)) {
+        if ($shouldSerialize) {
             $payload = $this->serializePayload($payload);
         }
         $this->payload = $payload;

--- a/src/Requests/MailchimpRequest.php
+++ b/src/Requests/MailchimpRequest.php
@@ -269,8 +269,9 @@ class MailchimpRequest
      */
     public function setPayload($payload)
     {
-        if (is_array($payload))
+        if (is_array($payload)) {
             $payload = $this->serializePayload($payload);
+        }
         $this->payload = $payload;
     }
 

--- a/src/Requests/MailchimpRequest.php
+++ b/src/Requests/MailchimpRequest.php
@@ -269,7 +269,8 @@ class MailchimpRequest
      */
     public function setPayload($payload)
     {
-        $payload = $this->serializePayload($payload);
+		if (is_array($payload))
+			$payload = $this->serializePayload($payload);
         $this->payload = $payload;
     }
 

--- a/src/Requests/MailchimpRequest.php
+++ b/src/Requests/MailchimpRequest.php
@@ -268,7 +268,7 @@ class MailchimpRequest
      * @param boolean $shouldSerialize
      * @throws MailchimpException when cant serialize payload
      */
-    public function setPayload($payload, $shouldSerialize = true))
+    public function setPayload($payload, $shouldSerialize = true)
     {
         if ($shouldSerialize) {
             $payload = $this->serializePayload($payload);


### PR DESCRIPTION
#### __**Description of change:**__
OAuth authentication was failing because the POST parameters being sent in the body were not properly encoded. The string was being JSON encoded.

See this page for info on OAuth parameters when redeeming a code for and access_token:
https://developer.mailchimp.com/documentation/mailchimp/guides/how-to-use-oauth2/



#### __**Description of implementation:**__

Added a check on `MailchimpRequest` payload to test if the input is an array or not. If it is an array, then proceed with the serialization (encoding into JSON).



#### __**Risks & Mitigation:**__
Other callers could be expecting different behavior out of `MailchimpRequest->setPayload()`
