### PR TITLE
Add custom curl settings options

### DIFF
--- a/src/Mailchimp.php
+++ b/src/Mailchimp.php
@@ -53,7 +53,9 @@ class Mailchimp
 
     /**
      * Retrieves a new AuthorizedApps instance.
+     *
      * @param null $app_id The ID for an app if retrieving an instance
+     *
      * @return Resources\AuthorizedApps
      */
     public function apps($app_id = null)
@@ -63,6 +65,7 @@ class Mailchimp
 
     /**
      * @param null $workflow_id
+     *
      * @return Resources\Automations
      */
     public function automations($workflow_id = null)
@@ -72,6 +75,7 @@ class Mailchimp
 
     /**
      * @param null $batch_id
+     *
      * @return Resources\BatchOperations
      */
     public function batches($batch_id = null)
@@ -81,6 +85,7 @@ class Mailchimp
 
     /**
      * @param null $batch_webhook_id
+     *
      * @return Resources\BatchWebhooks
      */
     public function batchWebhooks($batch_webhook_id = null)
@@ -90,6 +95,7 @@ class Mailchimp
 
     /**
      * @param null $folder_id
+     *
      * @return Resources\CampaignFolders
      */
     public function campaignFolders($folder_id = null)
@@ -99,6 +105,7 @@ class Mailchimp
 
     /**
      * @param null $campaign_id
+     *
      * @return Resources\Campaigns
      */
     public function campaigns($campaign_id = null)
@@ -108,6 +115,7 @@ class Mailchimp
 
     /**
      * @param null $site_id
+     *
      * @return Resources\ConnectedSites
      */
     public function connectedSites($site_id = null)
@@ -117,6 +125,7 @@ class Mailchimp
 
     /**
      * @param null $conversation_id
+     *
      * @return Resources\Conversations
      */
     public function conversations($conversation_id = null)
@@ -127,6 +136,7 @@ class Mailchimp
 
     /**
      * @param null $store_id
+     *
      * @return Resources\EcommerceStores
      */
     public function ecommerceStores($store_id = null)
@@ -136,6 +146,7 @@ class Mailchimp
 
     /**
      * @param null $outreach_id
+     *
      * @return Resources\FacebookAds
      */
     public function facebookAds($outreach_id = null)
@@ -145,6 +156,7 @@ class Mailchimp
 
     /**
      * @param null $file_id
+     *
      * @return Resources\FileManagerFiles
      */
     public function fileManagerFiles($file_id = null)
@@ -154,6 +166,7 @@ class Mailchimp
 
     /**
      * @param null $folder_id
+     *
      * @return Resources\FileManagerFolders
      */
     public function fileManagerFolders($folder_id = null)
@@ -163,6 +176,7 @@ class Mailchimp
 
     /**
      * @param null $outreach_id
+     *
      * @return Resources\GoogleAds
      */
     public function googleAds($outreach_id = null)
@@ -172,6 +186,7 @@ class Mailchimp
 
     /**
      * @param null $page_id
+     *
      * @return Resources\LandingPages
      */
     public function landingPages($page_id = null)
@@ -181,6 +196,7 @@ class Mailchimp
 
     /**
      * @param null $list_id
+     *
      * @return Resources\Lists
      */
     public function lists($list_id = null)
@@ -198,6 +214,7 @@ class Mailchimp
 
     /**
      * @param null $campaign_id
+     *
      * @return Resources\Reports
      */
     public function reports($campaign_id = null)
@@ -223,6 +240,7 @@ class Mailchimp
 
     /**
      * @param null $folder_id
+     *
      * @return Resources\TemplateFolders
      */
     public function templateFolders($folder_id = null)
@@ -232,6 +250,7 @@ class Mailchimp
 
     /**
      * @param null $template_id
+     *
      * @return Resources\Templates
      */
     public function templates($template_id = null)
@@ -252,12 +271,14 @@ class Mailchimp
     /**
      * @param $client_id
      * @param $redirect_uri
+     *
      * @return string
      */
     public static function getAuthUrl(
         $client_id,
         $redirect_uri
-    ) {
+    )
+    {
         $encoded_uri = urlencode($redirect_uri);
 
         $authUrl = "https://login.mailchimp.com/oauth2/authorize";
@@ -273,6 +294,7 @@ class Mailchimp
      * @param $client_id
      * @param $client_sec
      * @param $redirect_uri
+     *
      * @return string
      * @throws MailchimpException
      */
@@ -281,7 +303,8 @@ class Mailchimp
         $client_id,
         $client_sec,
         $redirect_uri
-    ) {
+    )
+    {
         $encoded_uri = urldecode($redirect_uri);
 
         $oauth_string = "grant_type=authorization_code";
@@ -298,6 +321,7 @@ class Mailchimp
 
     /**
      * @param $oauth_string
+     *
      * @return mixed
      * @throws MailchimpException
      */
@@ -324,6 +348,7 @@ class Mailchimp
 
     /**
      * @param $access_token
+     *
      * @return string
      * @throws MailchimpException
      */
@@ -344,6 +369,7 @@ class Mailchimp
 
     /**
      * @param MailchimpRequest $request
+     *
      * @return MailchimpConnection
      */
     protected static function getStaticConnection(MailchimpRequest $request)

--- a/src/Mailchimp.php
+++ b/src/Mailchimp.php
@@ -277,8 +277,7 @@ class Mailchimp
     public static function getAuthUrl(
         $client_id,
         $redirect_uri
-    )
-    {
+    ) {
         $encoded_uri = urlencode($redirect_uri);
 
         $authUrl = "https://login.mailchimp.com/oauth2/authorize";
@@ -303,8 +302,7 @@ class Mailchimp
         $client_id,
         $client_sec,
         $redirect_uri
-    )
-    {
+    ) {
         $encoded_uri = urldecode($redirect_uri);
 
         $oauth_string = "grant_type=authorization_code";
@@ -371,6 +369,8 @@ class Mailchimp
      * @param MailchimpRequest $request
      *
      * @return MailchimpConnection
+     *
+     * @throws MailchimpException
      */
     protected static function getStaticConnection(MailchimpRequest $request)
     {

--- a/src/Requests/HttpRequest.php
+++ b/src/Requests/HttpRequest.php
@@ -12,6 +12,7 @@ interface HttpRequest
     /**
      * @param $name
      * @param $value
+     *
      * @return mixed
      */
     public function setOption($name, $value);
@@ -23,6 +24,7 @@ interface HttpRequest
 
     /**
      * @param $name
+     *
      * @return mixed
      */
     public function getInfo($name);

--- a/src/Requests/MailchimpConnection.php
+++ b/src/Requests/MailchimpConnection.php
@@ -81,8 +81,11 @@ class MailchimpConnection implements HttpRequest
 
     /**
      * MailchimpConnection constructor.
-     * @param MailchimpRequest $request
+     *
+     * @param MailchimpRequest       $request
      * @param MailchimpSettings|null $settings
+     *
+     * @throws MailchimpException
      */
     public function __construct(MailchimpRequest &$request, MailchimpSettings &$settings = null)
     {
@@ -100,7 +103,10 @@ class MailchimpConnection implements HttpRequest
 
     /**
      * Prepares this connections handle for execution
+     *
      * @return void
+     *
+     * @throws MailchimpException
      */
     private function prepareHandle()
     {
@@ -124,6 +130,23 @@ class MailchimpConnection implements HttpRequest
 
         // set the callback to run against each of the response headers
         $this->setOption(CURLOPT_HEADERFUNCTION, [&$this, "parseResponseHeader"]);
+
+        // if an custom curl settings are present set them now
+        $this->setCustomHandleOptions($this->current_settings->getCustomCurlSettings());
+    }
+
+    /**
+     * Set custom curl handler options
+     *
+     * @param array $options
+     */
+    private function setCustomHandleOptions(array $options)
+    {
+        if (!empty($options)) {
+            foreach ($options as $option => $value) {
+                $this->setOption($option, $value);
+            }
+        }
     }
 
     /**
@@ -156,8 +179,8 @@ class MailchimpConnection implements HttpRequest
 
     /**
      * Executes a connection with the current request and settings
-     * @throws MailchimpException
      * @return MailchimpResponse
+     * @throws MailchimpException
      */
     public function execute()
     {
@@ -167,7 +190,7 @@ class MailchimpConnection implements HttpRequest
         }
 
         $this->http_code = $this->getInfo(CURLINFO_HTTP_CODE);
-        $head_len  = $this->getInfo(CURLINFO_HEADER_SIZE);
+        $head_len = $this->getInfo(CURLINFO_HEADER_SIZE);
         $this->response_body = substr(
             $this->response,
             $head_len,
@@ -193,7 +216,9 @@ class MailchimpConnection implements HttpRequest
 
     /**
      * Gets the currently set curl options by key
+     *
      * @param $key
+     *
      * @return mixed
      */
     public function getCurrentOption($key)
@@ -204,6 +229,7 @@ class MailchimpConnection implements HttpRequest
     /**
      * Bulk set curl options
      * Update current settings
+     *
      * @param array $options
      */
     public function setCurrentOptions($options)
@@ -254,6 +280,7 @@ class MailchimpConnection implements HttpRequest
      *
      * @param $handle
      * @param $header
+     *
      * @return int
      */
     private function parseResponseHeader($handle, $header)
@@ -263,7 +290,7 @@ class MailchimpConnection implements HttpRequest
         if (count($header_array) == 2) {
             $this->pushToHeaders($header_array);
         }
-        
+
         return $header_length;
     }
 

--- a/src/Requests/MailchimpRequest.php
+++ b/src/Requests/MailchimpRequest.php
@@ -112,7 +112,9 @@ class MailchimpRequest
 
     /**
      * MailchimpRequest constructor.
+     *
      * @param $apikey
+     *
      * @throws MailchimpException
      */
     public function __construct($apikey = null)
@@ -244,6 +246,7 @@ class MailchimpRequest
 
     /**
      * Set the api key
+     *
      * @param mixed $apikey
      */
     public function setApikey($apikey)
@@ -264,8 +267,10 @@ class MailchimpRequest
 
     /**
      * Sets the payload for a request
-     * @param mixed $payload
+     *
+     * @param mixed   $payload
      * @param boolean $shouldSerialize
+     *
      * @throws MailchimpException when cant serialize payload
      */
     public function setPayload($payload, $shouldSerialize = true)
@@ -278,6 +283,7 @@ class MailchimpRequest
 
     /**
      * Sets the endpoint for the request
+     *
      * @param mixed $endpoint
      */
     public function setEndpoint($endpoint)
@@ -287,7 +293,9 @@ class MailchimpRequest
 
     /**
      * Sets the request method
+     *
      * @param mixed $method
+     *
      * @throws MailchimpException
      */
     public function setMethod($method)
@@ -301,6 +309,7 @@ class MailchimpRequest
 
     /**
      * Sets the base URL
+     *
      * @param mixed $base_url
      */
     public function setBaseUrl($base_url)
@@ -310,6 +319,7 @@ class MailchimpRequest
 
     /**
      * Sets the query string from an array
+     *
      * @param array $query_array
      */
     public function setQueryString($query_array)
@@ -319,6 +329,7 @@ class MailchimpRequest
 
     /**
      * Sets the request headers
+     *
      * @param array $headers
      */
     public function setHeaders($headers)
@@ -328,6 +339,7 @@ class MailchimpRequest
 
     /**
      * Sets the success callback
+     *
      * @param callable $success_callback
      */
     public function setSuccessCallback(callable $success_callback)
@@ -337,6 +349,7 @@ class MailchimpRequest
 
     /**
      * Sets the failure callback
+     *
      * @param callable $failure_callback
      */
     public function setFailureCallback(callable $failure_callback)
@@ -350,7 +363,9 @@ class MailchimpRequest
 
     /**
      * JSON serializes the current payload
+     *
      * @param $payload
+     *
      * @return mixed
      * @throws MailchimpException
      */
@@ -367,7 +382,9 @@ class MailchimpRequest
 
     /**
      * Construct a query string from an array
+     *
      * @param array $query_input
+     *
      * @return string
      */
     public function constructQueryParams($query_input)
@@ -383,6 +400,7 @@ class MailchimpRequest
 
     /**
      * Adds a new header
+     *
      * @param string $header_string
      */
     public function addHeader($header_string)
@@ -395,6 +413,7 @@ class MailchimpRequest
 
     /**
      * Pushes a string to the end of the current endpoint
+     *
      * @param string $string
      */
     public function appendToEndpoint($string)
@@ -404,7 +423,9 @@ class MailchimpRequest
 
     /**
      * Checks for a valid API key
+     *
      * @param $exp_apikey
+     *
      * @throws MailchimpException
      */
     public function checkKey($exp_apikey)

--- a/src/Settings/MailchimpSettings.php
+++ b/src/Settings/MailchimpSettings.php
@@ -22,6 +22,10 @@ class MailchimpSettings
      * @var bool
      */
     private $verify_ssl = true;
+    /**
+     * @var array
+     */
+    private $custom_curl_settings = [];
 
 
     /*************************************
@@ -60,6 +64,15 @@ class MailchimpSettings
         return ($this->shouldDebug() && $this->getLogFile());
     }
 
+
+    /**
+     * @return array
+     */
+    public function getCustomCurlSettings()
+    {
+        return $this->custom_curl_settings;
+    }
+
     /*************************************
      * SETTERS
      *************************************/
@@ -93,5 +106,18 @@ class MailchimpSettings
     public function setVerifySsl($verify_ssl)
     {
         $this->verify_ssl = (bool) $verify_ssl;
+    }
+
+    /**
+     * Set custom curl options by providing a map of
+     * option => value
+     *
+     * @param array $options
+     */
+    public function setCustomCurlOptions(array $options)
+    {
+        foreach ($options as $option => $value) {
+            $this->custom_curl_settings[$option] = $value;
+        }
     }
 }

--- a/tests/Settings/MailchimpSettingsTest.php
+++ b/tests/Settings/MailchimpSettingsTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace MailchimpTests\Settings;
+
+use MailchimpAPI\Requests\MailchimpConnection;
+use MailchimpAPI\Requests\MailchimpRequest;
+use MailchimpAPI\Settings\MailchimpSettings;
+use MailchimpTests\MailChimpTestCase;
+
+class MailchimpSettingsTest extends MailChimpTestCase
+{
+    public function test_set_custom_curl_opts()
+    {
+        $mailchimp_request = new MailchimpRequest();
+        $mailchimp_settings = $this->getMockBuilder(MailchimpSettings::class)
+            ->setMethods(['getCustomCurlSettings', 'shouldVerifySsl'])
+            ->getMock();
+
+        $mailchimp_settings->method('shouldVerifySsl')
+            ->willReturn(true);
+
+        $mailchimp_settings->method('getCustomCurlSettings')
+            ->willReturn([]);
+
+        $mailchimp_settings->expects($this->once())
+            ->method('getCustomCurlSettings');
+
+        new MailchimpConnection($mailchimp_request, $mailchimp_settings);
+    }
+}


### PR DESCRIPTION
#### __**Description of change:**__
Adding functionality to create custom curl settings. 
Add test.
Cleanup some code.

#### __**Description of implementation:**__
Should be able to set an array of custom curl setting on MailchimpSettings that should remain persistent between request and set for every request.

#### __**Risks & Mitigation:**__
low - none
