### PR TITLE
fix broken ID check

### DIFF
--- a/src/Resources/Lists.php
+++ b/src/Resources/Lists.php
@@ -50,8 +50,7 @@ class Lists extends ApiResource
      */
     public function batchSubscribe($members = [], $update_existing = false)
     {
-
-        $this->throwIfNot("id", $this->subclass_resource);
+        $this->throwIfNot("id", $this->list_id);
         $params = [
             'members' => $members,
             'update_existing' => $update_existing


### PR DESCRIPTION
#### __**Description of change:**__
https://github.com/Jhut89/Mailchimp-API-3.0-PHP/issues/64


#### __**Description of implementation:**__
Change `$this->subclass_resource` to `$this->list_id`.



#### __**Risks & Mitigation:**__
Needs minor version bump.
