### PR TITLE
add switch for closing connections

### DIFF
--- a/src/Requests/MailchimpConnection.php
+++ b/src/Requests/MailchimpConnection.php
@@ -179,10 +179,13 @@ class MailchimpConnection implements HttpRequest
 
     /**
      * Executes a connection with the current request and settings
+     *
+     * @param bool $close close this connection after execution
+     *
      * @return MailchimpResponse
      * @throws MailchimpException
      */
-    public function execute()
+    public function execute($close = true)
     {
         $this->response = $this->executeCurl();
         if (!$this->response) {
@@ -196,6 +199,10 @@ class MailchimpConnection implements HttpRequest
             $head_len,
             strlen($this->response)
         );
+
+        if ($close) {
+            $this->close();
+        }
 
         if ($this->isSuccess()) {
             return new SuccessResponse(


### PR DESCRIPTION
#### __**Description of change:**__
Connections are not being cleaned up after their execution. This change should by default close connections after they are executed.  

Fix for https://github.com/Jhut89/Mailchimp-API-3.0-PHP/issues/67


#### __**Description of implementation:**__
Use bool switch to default to closing connections after they execute.



#### __**Risks & Mitigation:**__
low - none

