### PR TITLE
Added the ability to add custom user agent string

### DIFF
--- a/src/Mailchimp.php
+++ b/src/Mailchimp.php
@@ -294,8 +294,7 @@ class Mailchimp
     public static function getAuthUrl(
         $client_id,
         $redirect_uri
-    )
-    {
+    ) {
         $encoded_uri = urlencode($redirect_uri);
 
         $authUrl = "https://login.mailchimp.com/oauth2/authorize";
@@ -322,8 +321,7 @@ class Mailchimp
         $client_id,
         $client_sec,
         $redirect_uri
-    )
-    {
+    ) {
         $encoded_uri = urldecode($redirect_uri);
 
         $oauth_string = "grant_type=authorization_code";

--- a/src/Mailchimp.php
+++ b/src/Mailchimp.php
@@ -36,7 +36,7 @@ class Mailchimp
      *
      * @throws MailchimpException
      */
-    public function __construct($apikey, array $options)
+    public function __construct($apikey, $options = [])
     {
         $this->apikey = $apikey;
         $this->request = new MailchimpRequest($this->apikey);

--- a/src/Mailchimp.php
+++ b/src/Mailchimp.php
@@ -50,11 +50,11 @@ class Mailchimp
     /**
      * Set's the custom user agent string to be sent to Mailchimp
      *
-     * @param $user_agent
+     * @param $user_agent_string
      */
-    public function setCustomUserAgent($user_agent)
+    public function setCustomUserAgent($user_agent_string)
     {
-        $this->settings->setCustomUserAgent($user_agent);
+        $this->settings->setCustomUserAgentString($user_agent_string);
     }
 
     /**

--- a/src/Mailchimp.php
+++ b/src/Mailchimp.php
@@ -32,14 +32,29 @@ class Mailchimp
      * Mailchimp constructor.
      *
      * @param string $apikey
+     * @param array $options
      *
      * @throws MailchimpException
      */
-    public function __construct($apikey)
+    public function __construct($apikey, array $options)
     {
         $this->apikey = $apikey;
         $this->request = new MailchimpRequest($this->apikey);
         $this->settings = new MailchimpSettings();
+
+        if (isset($options['user_agent'])) {
+            $this->setCustomUserAgent($options['user_agent']);
+        }
+    }
+
+    /**
+     * Set's the custom user agent string to be sent to Mailchimp
+     *
+     * @param $user_agent
+     */
+    public function setCustomUserAgent($user_agent)
+    {
+        $this->settings->setCustomUserAgent($user_agent);
     }
 
     /**
@@ -279,7 +294,8 @@ class Mailchimp
     public static function getAuthUrl(
         $client_id,
         $redirect_uri
-    ) {
+    )
+    {
         $encoded_uri = urlencode($redirect_uri);
 
         $authUrl = "https://login.mailchimp.com/oauth2/authorize";
@@ -306,7 +322,8 @@ class Mailchimp
         $client_id,
         $client_sec,
         $redirect_uri
-    ) {
+    )
+    {
         $encoded_uri = urldecode($redirect_uri);
 
         $oauth_string = "grant_type=authorization_code";
@@ -328,7 +345,7 @@ class Mailchimp
     /**
      * Request an access token from Mailchimp
      *
-     * @param string           $oauth_string
+     * @param string $oauth_string
      * @param MailchimpRequest $request
      *
      * @return mixed
@@ -357,7 +374,7 @@ class Mailchimp
     /**
      * Construct an API key by requesting an access tokens data center
      *
-     * @param string           $access_token
+     * @param string $access_token
      * @param MailchimpRequest $request
      *
      * @return string

--- a/src/Requests/MailchimpConnection.php
+++ b/src/Requests/MailchimpConnection.php
@@ -82,7 +82,7 @@ class MailchimpConnection implements HttpRequest
     /**
      * MailchimpConnection constructor.
      *
-     * @param MailchimpRequest       $request
+     * @param MailchimpRequest $request
      * @param MailchimpSettings|null $settings
      *
      * @throws MailchimpException
@@ -117,7 +117,7 @@ class MailchimpConnection implements HttpRequest
         $this->setOption(CURLOPT_HTTPHEADER, $this->current_request->getHeaders());
 
         // set custom user-agent
-        $this->setOption(CURLOPT_USERAGENT, self::USER_AGENT);
+        $this->setOption(CURLOPT_USERAGENT, $this->getUserAgentString());
 
         // make response returnable
         $this->setOption(CURLOPT_RETURNTRANSFER, true);
@@ -324,5 +324,19 @@ class MailchimpConnection implements HttpRequest
     private function isSuccess()
     {
         return ($this->http_code > 199 && $this->http_code < 300);
+    }
+
+    /**
+     * Builds a custom user agent string to pass to Mailchimp depending on the option being passed through
+     * when constructing the class
+     *
+     * @return string
+     */
+    private function getUserAgentString()
+    {
+        if (!empty($this->current_settings->getCustomUserAgent())) {
+            return self::USER_AGENT . ';' . $this->current_settings->getCustomUserAgent();
+        }
+        return self::USER_AGENT;
     }
 }

--- a/src/Requests/MailchimpConnection.php
+++ b/src/Requests/MailchimpConnection.php
@@ -117,7 +117,7 @@ class MailchimpConnection implements HttpRequest
         $this->setOption(CURLOPT_HTTPHEADER, $this->current_request->getHeaders());
 
         // set custom user-agent
-        $this->setOption(CURLOPT_USERAGENT, $this->getUserAgentString());
+        $this->setOption(CURLOPT_USERAGENT, self::USER_AGENT);
 
         // make response returnable
         $this->setOption(CURLOPT_RETURNTRANSFER, true);
@@ -324,19 +324,5 @@ class MailchimpConnection implements HttpRequest
     private function isSuccess()
     {
         return ($this->http_code > 199 && $this->http_code < 300);
-    }
-
-    /**
-     * Builds a custom user agent string to pass to Mailchimp depending on the option being passed through
-     * when constructing the class
-     *
-     * @return string
-     */
-    private function getUserAgentString()
-    {
-        if (!empty($this->current_settings->getCustomUserAgent())) {
-            return self::USER_AGENT . ';' . $this->current_settings->getCustomUserAgent();
-        }
-        return self::USER_AGENT;
     }
 }

--- a/src/Settings/MailchimpSettings.php
+++ b/src/Settings/MailchimpSettings.php
@@ -3,6 +3,7 @@
 namespace MailchimpAPI\Settings;
 
 use MailchimpAPI\MailchimpException;
+use MailchimpAPI\Requests\MailchimpConnection;
 
 /**
  * Class MailchimpSettings
@@ -26,10 +27,6 @@ class MailchimpSettings
      * @var array
      */
     private $custom_curl_settings = [];
-    /**
-     * @var string
-     */
-    private $custom_user_agent = '';
 
 
     /*************************************
@@ -77,15 +74,6 @@ class MailchimpSettings
         return $this->custom_curl_settings;
     }
 
-
-    /**
-     * @return string
-     */
-    public function getCustomUserAgent()
-    {
-        return $this->custom_user_agent;
-    }
-
     /*************************************
      * SETTERS
      *************************************/
@@ -93,9 +81,10 @@ class MailchimpSettings
     /**
      * @param string $userAgentString
      */
-    public function setCustomUserAgent($userAgentString)
+    public function setCustomUserAgentString($userAgentString)
     {
-        $this->custom_user_agent = (string)$userAgentString;
+        $user_agent_String = MailchimpConnection::USER_AGENT . ';' . (string)$userAgentString;
+        $this->setCustomCurlSettings(['CURLOPT_USERAGENT' => $user_agent_String]);
     }
 
     /**

--- a/src/Settings/MailchimpSettings.php
+++ b/src/Settings/MailchimpSettings.php
@@ -79,12 +79,12 @@ class MailchimpSettings
      *************************************/
 
     /**
-     * @param string $userAgentString
+     * @param string $user_agent_string
      */
-    public function setCustomUserAgentString($userAgentString)
+    public function setCustomUserAgentString($user_agent_string)
     {
-        $user_agent_String = MailchimpConnection::USER_AGENT . ';' . (string)$userAgentString;
-        $this->setCustomCurlSettings(['CURLOPT_USERAGENT' => $user_agent_String]);
+        $custom_user_agent_string = MailchimpConnection::USER_AGENT . ';' . (string)$user_agent_string;
+        $this->setCustomCurlSettings(['CURLOPT_USERAGENT' => $custom_user_agent_string]);
     }
 
     /**

--- a/src/Settings/MailchimpSettings.php
+++ b/src/Settings/MailchimpSettings.php
@@ -26,6 +26,10 @@ class MailchimpSettings
      * @var array
      */
     private $custom_curl_settings = [];
+    /**
+     * @var string
+     */
+    private $custom_user_agent = '';
 
 
     /*************************************
@@ -73,9 +77,26 @@ class MailchimpSettings
         return $this->custom_curl_settings;
     }
 
+
+    /**
+     * @return string
+     */
+    public function getCustomUserAgent()
+    {
+        return $this->custom_user_agent;
+    }
+
     /*************************************
      * SETTERS
      *************************************/
+
+    /**
+     * @param string $userAgentString
+     */
+    public function setCustomUserAgent($userAgentString)
+    {
+        $this->custom_user_agent = (string)$userAgentString;
+    }
 
     /**
      * @param bool $debug

--- a/tests/MailchimpTest.php
+++ b/tests/MailchimpTest.php
@@ -56,4 +56,15 @@ final class MailchimpTest extends MailChimpTestCase
             "The settings must be an instance of a MailChimpSettings"
         );
     }
+
+    public function testSetUserAgentString()
+    {
+        $mc = $this->mailchimp;
+        $mc->setCustomUserAgent('Test Agent');
+
+        self::assertTrue(
+            $this->mailchimp->settings->getCustomUserAgent() == 'Test Agent',
+            "Agent string is not being saved correctly"
+        );
+    }
 }

--- a/tests/MailchimpTest.php
+++ b/tests/MailchimpTest.php
@@ -2,6 +2,7 @@
 
 namespace MailchimpTests;
 
+use MailchimpAPI\Requests\MailchimpConnection;
 use MailchimpAPI\Settings\MailchimpSettings;
 use MailchimpAPI\Requests\MailchimpRequest;
 
@@ -60,10 +61,11 @@ final class MailchimpTest extends MailChimpTestCase
     public function testSetUserAgentString()
     {
         $mc = $this->mailchimp;
-        $mc->setCustomUserAgent('Test Agent');
+        $customUserAgentString = "Test Agent";
+        $mc->setCustomUserAgent($customUserAgentString);
 
         self::assertTrue(
-            $this->mailchimp->settings->getCustomUserAgent() == 'Test Agent',
+            $this->mailchimp->settings->getCustomCurlSettings()['CURLOPT_USERAGENT'] == MailchimpConnection::USER_AGENT . ';' . $customUserAgentString,
             "Agent string is not being saved correctly"
         );
     }


### PR DESCRIPTION
#### __**Description of change:**__
For better logging within Mailchimp for support reason, being able to send the user agent string is helpful. 

Fix for #69



#### __**Description of implementation:**__
Added in a second parameter to class construction to pass through an array of options. Currently, the user agent string is the only thing that is used but opens for the future. If this is not the desired way to implement this, in the constructor, it calls a method to set the user agent string, so this if this is preferred, we can remove the $option parameter



#### __**Risks & Mitigation:**__
Low
