### PR TITLE
3.1.4 | update require dev to resolve build dependency errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ sudo: required
 dist: trusty
 language: php
 php:
-  - '5.6'
-  - '7.0'
+  - '7.2'
 before-script:
   - composer install
   - composer update

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     },
     "homepage": "https://github.com/Jhut89/Mailchimp-API-3.0-PHP",
     "require-dev": {
+        "php": ">=7.2.0",
         "phpunit/phpunit": "^5",
         "squizlabs/php_codesniffer": "3.*"
     }


### PR DESCRIPTION
#### __**Description of change:**__
Currently the dev build is failing due to dependancies requiring php 7.1 or up this change updates require-dev to use 7.2. I will merge once the build repo has been updated.


