### PR TITLE
Pass response to success/failure callbacks

### DIFF
--- a/src/Requests/MailchimpRequest.php
+++ b/src/Requests/MailchimpRequest.php
@@ -451,6 +451,10 @@ class MailchimpRequest
         $apikey = $this->apikey;
         $request_vars = get_object_vars($this);
         foreach ($request_vars as $key => $value) {
+            if (in_array($key, ['success_callback', 'failure_callback'], true)) {
+                continue;
+            }
+            
             $this->$key = null;
             if ($key == 'headers') {
                 $this->$key = [];

--- a/src/Requests/MailchimpRequest.php
+++ b/src/Requests/MailchimpRequest.php
@@ -456,7 +456,7 @@ class MailchimpRequest
             }
             
             $this->$key = null;
-            if ($key == 'headers') {
+            if ('headers' === $key) {
                 $this->$key = [];
             }
         }

--- a/src/Responses/FailureResponse.php
+++ b/src/Responses/FailureResponse.php
@@ -23,7 +23,7 @@ class FailureResponse extends MailchimpResponse
         parent::__construct($headers, $body, $http_code);
 
         if ($failure_callback) {
-            call_user_func($failure_callback);
+            call_user_func($failure_callback, $this);
         }
     }
 }

--- a/src/Responses/FailureResponse.php
+++ b/src/Responses/FailureResponse.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace MailchimpAPI\Responses;
-
 
 /**
  * Class FailureResponse

--- a/src/Responses/SuccessResponse.php
+++ b/src/Responses/SuccessResponse.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace MailchimpAPI\Responses;
-
 
 /**
  * Class SuccessResponse

--- a/src/Responses/SuccessResponse.php
+++ b/src/Responses/SuccessResponse.php
@@ -23,7 +23,7 @@ class SuccessResponse extends MailchimpResponse
         parent::__construct($headers, $body, $http_code);
 
         if ($success_callback) {
-            call_user_func($success_callback);
+            call_user_func($success_callback, $this);
         }
     }
 }


### PR DESCRIPTION
#### __**Description of change:**__
Pass response to success/failure callbacks is needed because there is no another way to access response in callback