### PR TITLE
add support for OAuth state variable

### DIFF
--- a/src/Mailchimp.php
+++ b/src/Mailchimp.php
@@ -273,12 +273,14 @@ class Mailchimp
      *
      * @param $client_id
      * @param $redirect_uri
+     * @param $state
      *
      * @return string
      */
     public static function getAuthUrl(
         $client_id,
-        $redirect_uri
+        $redirect_uri,
+        $state = null
     ) {
         $encoded_uri = urlencode($redirect_uri);
 
@@ -286,6 +288,10 @@ class Mailchimp
         $authUrl .= "?client_id=" . $client_id;
         $authUrl .= "&redirect_uri=" . $encoded_uri;
         $authUrl .= "&response_type=code";
+
+        if ($state !== null) {
+            $authUrl .= "&state=" . $state;
+        }
 
         return $authUrl;
     }


### PR DESCRIPTION
#### __**Description of change:**__

MailChimp is removing support for wild card `redirect_uri`s. Per their recent email, copied below, OAuth developers will no longer be able to use fuzzy matching on the redirect uri, and will be required to use a `state` parameter to pass any state needed for user or route specific info.

This change is to add support for a `state` parameter to the OAuth url. 

```
To maintain best security practices for our product and for our partner integrations, we’re making a change to how we handle the OAuth redirect that’s used when authenticating registered apps to Mailchimp. By November 10, 2020, you or your developer will need to verify that your app 1) has a saved_URI that matches the submitted_URI, and 2) uses a state parameter if it needs to pass user- or route-specific data.

We’ve determined that this security change impacts your app. Below you’ll find more information about this change and what you need to do.

Background
We require integrations that use OAuth to configure a redirect URI. The user is redirected to this URI after they’ve successfully authenticated with Mailchimp. Previously, we allowed the URI to use fuzzy matching, which means the URI for the registered app didn’t need to be exactly the same as the redirect URI.

Allowing for fuzzy matching isn’t a security best practice, so we’re requiring all current and future registered apps to have a redirect URI that matches their registered URI. 

What you need to do
We’ve determined that your registered app uses OAuth and has at least one redirect URI that doesn't match the registered URI.

Before November 10, you or your developer will want to check that both of the following are true.

Ensure saved_URI and submitted_URI match

It’s a common misconception that the submitted_URI needs to be different for each type of authorization request. This can actually be a security risk, as outlined in the resource linked below.

To ensure your registered app continues to authenticate with Mailchimp after November 10, you’ll want to ensure that the saved_URI matches the submitted_URI.

Use state parameter to pass user- or route-specific data

Depending on the need of your registered app, you may not need to pass user- or route-specific data with your redirect. If you do, however, you can use a state parameter to store data that will be included after the user is redirected.

Additional resources

Okta provides great information about OAuth. In particular, their resource on Redirect URL Registration will give additional context to the importance of having matching registered and redirect URIs and how to use the state parameter.

Questions
If you have any additional questions, please feel free to reply to this email and we’ll be happy to help. 

 
– Mailchimp
```


#### __**Description of implementation:**__

Added a `state` argument to the `Mailchimp->getAuthUrl()` function, and used it to append a `state` parameter to the `authUrl`. To keep the API backward compatible, the `state` parameter is not required, and defaults to `null`.


#### __**Risks & Mitigation:**__

Backward compatibility with the API, but this addressed by making the added argument not required, and by giving it a default value.
