### PR TITLE
Fix to Mailchimp failing to respond to Expect: 100-Continue headers

### DIFF
--- a/src/Requests/MailchimpRequest.php
+++ b/src/Requests/MailchimpRequest.php
@@ -210,6 +210,7 @@ class MailchimpRequest
         if (!is_array($this->headers)) {
             throw new MailchimpException("Request headers must be of type array");
         }
+        $this->headers[] = 'Expect:';
         return $this->headers;
     }
 

--- a/tests/UtilityTests/MailchimpRequestTest.php
+++ b/tests/UtilityTests/MailchimpRequestTest.php
@@ -24,6 +24,15 @@ final class MailchimpRequestTest extends MailChimpTestCase
         self::assertEquals($expected, $actual, "Auth Header should be appropriately set");
     }
 
+    public function testExpectHeaderNotSet()
+    {
+        error_log(print_r($this->requestInstance->getHeaders(), true));
+        $expected = 'Expect:';
+        $actual = $this->requestInstance->getHeaders()[1];
+
+        self::assertEquals($expected, $actual, "Expect header should never be set");
+    }
+
     public function testApikeySet()
     {
         self::assertEquals(

--- a/tests/UtilityTests/MailchimpRequestTest.php
+++ b/tests/UtilityTests/MailchimpRequestTest.php
@@ -26,11 +26,9 @@ final class MailchimpRequestTest extends MailChimpTestCase
 
     public function testExpectHeaderNotSet()
     {
-        error_log(print_r($this->requestInstance->getHeaders(), true));
         $expected = 'Expect:';
         $actual = $this->requestInstance->getHeaders()[1];
-
-        self::assertEquals($expected, $actual, "Expect header should never be set");
+        self::assertEquals($expected, $actual, "Expect header should be empty");
     }
 
     public function testApikeySet()


### PR DESCRIPTION
#### __**Description of change:**__

We discovered in the past week that Mailchimp does not respond to large patch payloads.
Further digging discovered that php curl is automatically adding the Expect: 100-continue header to the request which was causing the majority of our Patch requests to fail.


#### __**Description of implementation:**__

To fix this we have set an empty Expect: in the get headers function.


#### __**Risks & Mitigation:**__

Unit test written.. 
